### PR TITLE
Config file name must match webapp.

### DIFF
--- a/docs/ConfiguringDatabaseAccess.md
+++ b/docs/ConfiguringDatabaseAccess.md
@@ -8,7 +8,7 @@ from the Application Container via JNDI.
 
 Setting up the JNDI datasource on Tomcat.
 
-1. You can create `comms-router-web-api.xml` in `$CATALINA_BASE/conf/[enginename]/[hostname]/`
+1. You can create `comms-router-web.xml` in `$CATALINA_BASE/conf/[enginename]/[hostname]/`
     or use some other relevant file. [See Documentation][1]
 
     Alternatively this resource can be added to encompassing contexts defined in `$CATALINA_BASE/conf/context.xml` or in `$CATALINA_BASE/conf/[engine_name]/context.xml`.


### PR DESCRIPTION
Naming the file with '-api' resulted in a NamingException when looking up the JNDI path.