### PR TITLE
Fix for #68:

### DIFF
--- a/common/src/main/java/com/softavail/commsrouter/jpa/JpaTransactionManager.java
+++ b/common/src/main/java/com/softavail/commsrouter/jpa/JpaTransactionManager.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2017 SoftAvail Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,6 +115,12 @@ public class JpaTransactionManager {
       throws CommsRouterException {
 
     execute(voidTransactionLogic);
+  }
+
+  public void executeVoidWithLockRetry(VoidTransactionLogic voidTransactionLogic)
+      throws CommsRouterException {
+
+    execute(lockRetryCount, voidTransactionLogic);
   }
 
   public void close() {

--- a/core-interface/src/main/java/com/softavail/commsrouter/api/dto/model/TaskState.java
+++ b/core-interface/src/main/java/com/softavail/commsrouter/api/dto/model/TaskState.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2017 SoftAvail Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ package com.softavail.commsrouter.api.dto.model;
  */
 public enum TaskState {
 
-  waiting(true), assigned(false), completed(true);
+  waiting(true), canceled(true), assigned(false), completed(true);
 
   private boolean deleteAllowed;
 
@@ -32,6 +32,10 @@ public enum TaskState {
 
   public boolean isWaiting() {
     return this == waiting;
+  }
+
+  public boolean isCanceled() {
+    return this == canceled;
   }
 
   public boolean isAssigned() {
@@ -44,6 +48,10 @@ public enum TaskState {
 
   public boolean isDeleteAllowed() {
     return deleteAllowed;
+  }
+
+  public boolean isFinal() {
+    return this == completed || this == canceled;
   }
 
 }

--- a/core/src/main/java/com/softavail/commsrouter/api/service/CoreAgentService.java
+++ b/core/src/main/java/com/softavail/commsrouter/api/service/CoreAgentService.java
@@ -224,7 +224,7 @@ public class CoreAgentService extends CoreRouterObjectService<AgentDto, Agent>
         agentBecameAvailable = false;
         break;
       default:
-        throw new InternalErrorException("Unexpected agent state");
+        throw new InternalErrorException("Unexpected agent state: " + oldState);
     }
     agent.setState(newState);
     return agentBecameAvailable;

--- a/core/src/main/java/com/softavail/commsrouter/domain/Task.java
+++ b/core/src/main/java/com/softavail/commsrouter/domain/Task.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2017 SoftAvail Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -200,7 +200,7 @@ public class Task extends RouterObject {
   public void setExpirationDate(Date expirationDate) {
     this.expirationDate = expirationDate;
   }
-  
+
   public String getTag() {
     return tag;
   }
@@ -220,7 +220,16 @@ public class Task extends RouterObject {
   }
 
   public void makeCompleted() {
-    setState(TaskState.completed);
+    makeFinal(TaskState.completed);
+  }
+
+  public void makeCanceled() {
+    makeFinal(TaskState.canceled);
+  }
+
+  private void makeFinal(TaskState state) {
+    assert state.isFinal();
+    setState(state);
     setQueue(null);
     setAgent(null);
     setRule(null);

--- a/core/src/test/java/com/softavail/commsrouter/jpa/test/CoreTaskServiceJpaTest.java
+++ b/core/src/test/java/com/softavail/commsrouter/jpa/test/CoreTaskServiceJpaTest.java
@@ -41,16 +41,15 @@ public class CoreTaskServiceJpaTest extends TestBase {
     assertEquals(task.get(0).getCallbackUrl(), "https://test.com");
   }
 
-  // Testing the update method
   @Test
-  public void updateTest() throws CommsRouterException, MalformedURLException {
+  public void cancelTest() throws CommsRouterException, MalformedURLException {
     RouterObjectRef ref = new RouterObjectRef("", "01");
     ApiObjectRef queue = queueService.replace(newCreateQueueArg("1==1", "desctiption_one"), ref);
     taskService.replace(newCreateTaskArg(queue.getRef(), "https://test_one.com", null), ref);
     // Updating
-    taskService.update(newUpdateTaskArg(2, TaskState.completed), ref);
+    taskService.update(newUpdateTaskArg(2, TaskState.canceled), ref);
     TaskDto task = taskService.get(ref);
-    assertEquals(task.getState(), TaskState.completed);
+    assertEquals(task.getState(), TaskState.canceled);
   }
 
   // Testing the update method that updates the TaskContext

--- a/test/api-test/src/test/java/com/softavail/api/test/AgentTest.java
+++ b/test/api-test/src/test/java/com/softavail/api/test/AgentTest.java
@@ -258,7 +258,7 @@ public class AgentTest {
     assertThat(String.format("Check agent state (%s) to be unavailable.", resource.getState()),
         resource.getState(), is(AgentState.unavailable));
 
-    t.setState(TaskState.completed);
+    t.setState(TaskState.canceled);
 
     assertThat(q.size(), is(0));
 

--- a/test/api-test/src/test/java/com/softavail/api/test/AppTest.java
+++ b/test/api-test/src/test/java/com/softavail/api/test/AppTest.java
@@ -154,7 +154,7 @@ public class AppTest {
     assertThat(t.list(), hasItems(hasProperty("ref", is(ref.getRef()))));
     t.replace(new CreateTaskArg.Builder().callback(new URL("http://localhost:8080"))
         .queue(queueRef.getRef()).build());
-    t.update(new UpdateTaskArg.Builder().state(TaskState.completed).build());
+    t.update(new UpdateTaskArg.Builder().state(TaskState.canceled).build());
     t.delete();
     q.delete();
     r.delete();


### PR DESCRIPTION
  - introduce new state: canceled
  - adjust verification for allowed state transitions
  - run user requested state changes via lock retry

In state of collision with state changes by the router
the retry will report invalid state.